### PR TITLE
implements torch sdpa

### DIFF
--- a/model.py
+++ b/model.py
@@ -34,9 +34,7 @@ class CausalSelfAttention(nn.Module):
         # regularization
         self.attn_dropout = nn.Dropout(config.dropout)
         self.resid_dropout = nn.Dropout(config.dropout)
-        # causal mask to ensure that attention is only applied to the left in the input sequence
-        self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
-                                    .view(1, 1, config.block_size, config.block_size))
+
         self.n_head = config.n_head
         self.n_embd = config.n_embd
         self.dropout = config.dropout
@@ -60,6 +58,7 @@ class CausalSelfAttention(nn.Module):
             need_attn_weights=False,
             is_causal=True,
         )
+        y = att @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
         y = y.transpose(1, 2).contiguous().view(B, T, C) # re-assemble all head outputs side by side
 
         # output projection

--- a/model.py
+++ b/model.py
@@ -49,14 +49,8 @@ class CausalSelfAttention(nn.Module):
         v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
 
         # the output of sdp = (batch, num_heads, seq_len, head_dim)
-        y = torch.nn.functional.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            attn_mask=None,
-            dropout_p=self.dropout,
-            is_causal=True,
-        )
+        y = torch.nn.functional.scaled_dot_product_attention(q, k, v, None, self.dropout, True)
+
         y = att @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
         y = y.transpose(1, 2).contiguous().view(B, T, C) # re-assemble all head outputs side by side
 

--- a/model.py
+++ b/model.py
@@ -49,13 +49,12 @@ class CausalSelfAttention(nn.Module):
         v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
 
         # the output of sdp = (batch, num_heads, seq_len, head_dim)
-        y, _ = torch.nn.functional._scaled_dot_product_attention(
+        y = torch.nn.functional.scaled_dot_product_attention(
             q,
             k,
             v,
             attn_mask=None,
             dropout_p=self.dropout,
-            need_attn_weights=False,
             is_causal=True,
         )
         y = att @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
@@ -101,6 +100,7 @@ class GPTConfig:
     n_layer: int = 12
     n_head: int = 12
     n_embd: int = 768
+    # setting dropout to 0.0 is necessary for fused Flash Attention kernel
     dropout: float = 0.0
 
 class GPT(nn.Module):


### PR DESCRIPTION
Implements torch sdpa for mem_efficient kernel support

Using the mem_efficient kernel results in a ~15.5% faster training time per batch, going from a ~154ms/batch baseline to ~130ms/batch.

Potentially improves on overflow protection, since `mem_efficient` kernel scales q & k matrices before multiplying

Setting dropout to 0.0 is necessary to support the flash attention kernel. This will no longer be necessary after https://github.com/pytorch/pytorch/pull/92917 is landed